### PR TITLE
Add end of file check to loop

### DIFF
--- a/OBJLoader.cs
+++ b/OBJLoader.cs
@@ -197,7 +197,7 @@ namespace Dummiesman
                 if (buffer.Is("f"))
                 {
                     //loop through indices
-                    while (true)
+                    while (!buffer.endReached)
                     {
 						bool newLinePassed;
 						buffer.SkipWhitespaces(out newLinePassed);


### PR DESCRIPTION
Thank you for the very helpful OBJ importer package!

I was surprised by a case in which the code enters a tight loop that causes an out of memory error. The problem can be triggered by loading an OBJ file that ends with a face ("f") line which is not terminated by a newline character. The problem can be easily prevented by replacing the unconditional `while(true)` loop with a check for the end of file condition. I hope this change can help others avoid frustration.